### PR TITLE
Stack direction and minimal display proof of concept

### DIFF
--- a/CurrencyAlert/Configuration.cs
+++ b/CurrencyAlert/Configuration.cs
@@ -15,7 +15,7 @@ namespace CurrencyAlert
 
         public bool UiLocked { get; set; } = false;
         public bool MinimalDisplay { get; set; } = false;
-        public SortDirection SortDirection { get; set;} = 0;
+        public StackDirection StackDirection { get; set;} = 0;
         public Dictionary<int, bool> AlertEnabled { get; } = new Dictionary<int, bool>();
         public Dictionary<int, int> Threshold { get; } = new Dictionary<int, int>();
 

--- a/CurrencyAlert/Configuration.cs
+++ b/CurrencyAlert/Configuration.cs
@@ -1,4 +1,5 @@
-﻿using CurrencyAlert.Helper;
+﻿using CurrencyAlert.Enum;
+using CurrencyAlert.Helper;
 using CurrencyAlert.Provider;
 using Dalamud.Configuration;
 using Dalamud.Plugin;
@@ -13,6 +14,8 @@ namespace CurrencyAlert
         public int Version { get; set; } = 5;
 
         public bool UiLocked { get; set; } = false;
+        public bool MinimalDisplay { get; set; } = false;
+        public SortDirection SortDirection { get; set;} = 0;
         public Dictionary<int, bool> AlertEnabled { get; } = new Dictionary<int, bool>();
         public Dictionary<int, int> Threshold { get; } = new Dictionary<int, int>();
 

--- a/CurrencyAlert/Enum/SortDirection.cs
+++ b/CurrencyAlert/Enum/SortDirection.cs
@@ -1,0 +1,10 @@
+﻿namespace CurrencyAlert.Enum
+{
+    public enum SortDirection
+    {
+        Up, 
+        Down, 
+        Left, 
+        Right
+    }
+}

--- a/CurrencyAlert/Enum/StackDirection.cs
+++ b/CurrencyAlert/Enum/StackDirection.cs
@@ -1,6 +1,6 @@
 ﻿namespace CurrencyAlert.Enum
 {
-    public enum SortDirection
+    public enum StackDirection
     {
         Up, 
         Down, 

--- a/CurrencyAlert/PluginUI.cs
+++ b/CurrencyAlert/PluginUI.cs
@@ -52,11 +52,11 @@ namespace CurrencyAlert
         {
             lastMainWindowPos = ImGui.GetWindowPos();
 
-            if (this.configuration.SortDirection == SortDirection.Up)
+            if (this.configuration.StackDirection == StackDirection.Up)
             {
                 lastMainWindowPos.Y += ImGui.GetWindowHeight();
             }
-            else if (this.configuration.SortDirection == SortDirection.Left)
+            else if (this.configuration.StackDirection == StackDirection.Left)
             {
                 lastMainWindowPos.X += ImGui.GetWindowWidth();
             }
@@ -91,11 +91,11 @@ namespace CurrencyAlert
                 {
                     Vector2 newPos = new Vector2 { X = lastMainWindowPos.X, Y = lastMainWindowPos.Y };
 
-                    if (this.configuration.SortDirection == SortDirection.Up)
+                    if (this.configuration.StackDirection == StackDirection.Up)
                     {
                         newPos.Y -= ImGui.GetWindowHeight();
                     }
-                    else if (this.configuration.SortDirection == SortDirection.Left)
+                    else if (this.configuration.StackDirection == StackDirection.Left)
                     {
                         newPos.X -= ImGui.GetWindowWidth();
                     }
@@ -111,7 +111,7 @@ namespace CurrencyAlert
                     if (first)
                     {
                         ImGui.Text($"You need to spend your");
-                        if (this.configuration.SortDirection == SortDirection.Left || this.configuration.SortDirection == SortDirection.Right)
+                        if (this.configuration.StackDirection == StackDirection.Left || this.configuration.StackDirection == StackDirection.Right)
                         {
                             first = false;
                         }
@@ -129,7 +129,7 @@ namespace CurrencyAlert
                         ImGui.Text($"{currency.Name}");
                     }
 
-                    if (this.configuration.SortDirection == SortDirection.Left || this.configuration.SortDirection == SortDirection.Right)
+                    if (this.configuration.StackDirection == StackDirection.Left || this.configuration.StackDirection == StackDirection.Right)
                     {
                         ImGui.SameLine();
                     }
@@ -161,10 +161,10 @@ namespace CurrencyAlert
                     this.configuration.Save();
                 }
 
-                int sortDirection = (int) this.configuration.SortDirection;
-                if (ImGui.Combo("Sort Direction", ref sortDirection, new string[] { "Up", "Down", "Left", "Right" }, 4))
+                int stackDirection = (int) this.configuration.StackDirection;
+                if (ImGui.Combo("Stack Direction", ref stackDirection, new string[] { "Up", "Down", "Left", "Right" }, 4))
                 {
-                    this.configuration.SortDirection = (SortDirection) sortDirection;
+                    this.configuration.StackDirection = (StackDirection) stackDirection;
                     this.configuration.Save();
                 };
 


### PR DESCRIPTION
Allows for the ability to change the stack direction (up, down, left and right) as well as a minimal mode, where the name of the currency is not displayed.

![image](https://user-images.githubusercontent.com/24492062/202427854-5a744fe9-6d26-4443-a286-6c90fe319183.png)
![image](https://user-images.githubusercontent.com/24492062/202428072-2597958a-1d52-4a68-b3c8-3b4115c47f89.png)
![image](https://user-images.githubusercontent.com/24492062/202428100-939e0b34-bd0f-4ff4-b8ec-f541c6610671.png)
